### PR TITLE
Added login ability, cosmetic changes per login

### DIFF
--- a/src/client/client.html
+++ b/src/client/client.html
@@ -270,9 +270,9 @@ button:active,
 }
 
 
-input[type=text] { all: unset; }
+input[type=text], input[type=password] { all: unset; }
 
-input[type=text],
+input[type=text], input[type=password],
 .g-input {
     min-width: 22px;
     min-height: 2px;
@@ -1129,12 +1129,12 @@ input[type=text],
 
                 .pony-label {
                     /* Make it match the other option labels. */
-                    width: 4rem;
+                    width: 5rem;
                     padding: 0.125rem;
                     text-align: left;
                     flex-shrink: 0;
                 }
-                .pony-name {
+                .pony-name, .pony-password {
                     border: none;
                     font-size: 1rem;
                     background-color: transparent;
@@ -1196,6 +1196,10 @@ input[type=text],
                 <div class="pony-row" data-part="name-row">
                     <div class="pony-label">Name: </div>
                     <input type="text" class="pony-name" size="16" data-part="name-field">
+                </div>
+                <div class="pony-row" data-part="password-row">
+                    <div class="pony-label">Password: </div>
+                    <input type="password" class="pony-password" size="16" data-part="password-field" placeholder="(Optional)">
                 </div>
                 <div class="pony-editor-middle">
                     <div data-part="options"></div>

--- a/src/client/js/main.js
+++ b/src/client/js/main.js
@@ -71,6 +71,7 @@ var rle16Decode = require('util/misc').rle16Decode;
 var buildArray = require('util/misc').buildArray;
 var checkBrowser = require('util/browser').checkBrowser;
 var util = require('util/misc');
+var murmurHash3 = require('util/murmurHash3').murmurHash3;
 
 
 var anim_dirs = [
@@ -364,13 +365,14 @@ function maybeRegister(info, next) {
 
     var last_name = null;
 
-    function send_register(name, app_info) {
+    function send_register(name, app_info, pw) {
         editor.onfinish = null;
         editor.setMessage("Registering...");
         last_name = name;
 
         var appearance = calcAppearance(app_info);
         saveAppearance(app_info);
+        secret = pw ? makeSecretFromPassword(pw) : secret;
         conn.onRegisterResult = handle_result;
         conn.sendRegister(name,
                           secret,
@@ -491,6 +493,11 @@ function makeSecret() {
         }
     }
     return secret_buf;
+}
+
+function makeSecretFromPassword(pw) {
+    var hash = murmurHash3.x86.hash128(pw);
+    return hash.match(/.{1,8}/g).map(function(x) { return parseInt(x, 16); });
 }
 
 function calcAppearance(a) {

--- a/src/client/js/ui/ponyedit.js
+++ b/src/client/js/ui/ponyedit.js
@@ -46,6 +46,9 @@ function PonyEditor(name, draw) {
     this.name = new widget.TextField(parts['name-field']);
     var nameRow = new widget.Container(parts['name-row'], this.name);
 
+    this.password = new widget.TextField(parts['password-field']);
+    var passwordRow = new widget.Container(parts['password-row'], this.password);
+
     function rowWidget(parts) {
         var items = new Array(parts.items.length);
         for (var i = 0; i < parts.items.length; ++i) {
@@ -70,7 +73,7 @@ function PonyEditor(name, draw) {
     done.onclick = function() { this_.submit(); };
 
     var list = new widget.SimpleList(parts['top'],
-            [nameRow, this.sex, this.tribe,
+            [nameRow, passwordRow, this.sex, this.tribe,
              this.mane, this.tail,
              this.red, this.green, this.blue,
              done]);
@@ -94,12 +97,21 @@ function PonyEditor(name, draw) {
 
     // Initial setup
 
+    var moveCursorToEndGenerator = function(domElem) {
+        return function() {
+            var len = domElem.value.length;
+            domElem.setSelectionRange(len, len);
+        }
+    }
+
     this.name.dom.value = name;
     var name_dom = this.name.dom;
-    this.name.onfocus = util.chain(this.name.onfocus, function() {
-        var len = name_dom.value.length;
-        name_dom.setSelectionRange(len, len);
-    });
+    this.name.onfocus = util.chain(this.name.onfocus,
+                                   moveCursorToEndGenerator(name_dom));
+
+    var password_dom = this.password.dom;
+    this.password.onfocus = util.chain(this.name.onfocus,
+                                       moveCursorToEndGenerator(password_dom))
 
     // Disable drawing during initialization.
     this.draw = function() { };
@@ -176,7 +188,8 @@ PonyEditor.prototype.submit = function() {
     console.log('submit');
     if (this.onsubmit != null) {
         var name = this.name.dom.value;
-        this.onsubmit(name, this._getAppearanceInfo());
+        var password = this.password.dom.value;
+        this.onsubmit(name, this._getAppearanceInfo(), password);
     }
 };
 

--- a/src/client/js/util/murmurHash3.js
+++ b/src/client/js/util/murmurHash3.js
@@ -1,0 +1,586 @@
+// +----------------------------------------------------------------------+
+// | murmurHash3.js v2.1.2 (http://github.com/karanlyons/murmurHash.js)   |
+// | A javascript implementation of MurmurHash3's x86 hashing algorithms. |
+// |----------------------------------------------------------------------|
+// | Copyright (c) 2012 Karan Lyons                                       |
+// | Freely distributable under the MIT license.                          |
+// +----------------------------------------------------------------------+
+
+
+;(function (root, undefined) {
+	'use strict';
+	
+	// Create a local object that'll be exported or referenced globally.
+	var library = {
+		'version': '2.1.2',
+		'x86': {},
+		'x64': {}
+	};
+	
+	
+	
+	
+	// PRIVATE FUNCTIONS
+	// -----------------
+	
+	function _x86Multiply(m, n) {
+		//
+		// Given two 32bit ints, returns the two multiplied together as a
+		// 32bit int.
+		//
+		
+		return ((m & 0xffff) * n) + ((((m >>> 16) * n) & 0xffff) << 16);
+	}
+	
+	
+	function _x86Rotl(m, n) {
+		//
+		// Given a 32bit int and an int representing a number of bit positions,
+		// returns the 32bit int rotated left by that number of positions.
+		//
+		
+		return (m << n) | (m >>> (32 - n));
+	}
+	
+	
+	function _x86Fmix(h) {
+		//
+		// Given a block, returns murmurHash3's final x86 mix of that block.
+		//
+		
+		h ^= h >>> 16;
+		h  = _x86Multiply(h, 0x85ebca6b);
+		h ^= h >>> 13;
+		h  = _x86Multiply(h, 0xc2b2ae35);
+		h ^= h >>> 16;
+		
+		return h;
+	}
+	
+	
+	function _x64Add(m, n) {
+		//
+		// Given two 64bit ints (as an array of two 32bit ints) returns the two
+		// added together as a 64bit int (as an array of two 32bit ints).
+		//
+		
+		m = [m[0] >>> 16, m[0] & 0xffff, m[1] >>> 16, m[1] & 0xffff];
+		n = [n[0] >>> 16, n[0] & 0xffff, n[1] >>> 16, n[1] & 0xffff];
+		var o = [0, 0, 0, 0];
+		
+		o[3] += m[3] + n[3];
+		o[2] += o[3] >>> 16;
+		o[3] &= 0xffff;
+		
+		o[2] += m[2] + n[2];
+		o[1] += o[2] >>> 16;
+		o[2] &= 0xffff;
+		
+		o[1] += m[1] + n[1];
+		o[0] += o[1] >>> 16;
+		o[1] &= 0xffff;
+		
+		o[0] += m[0] + n[0];
+		o[0] &= 0xffff;
+		
+		return [(o[0] << 16) | o[1], (o[2] << 16) | o[3]];
+	}
+	
+	
+	function _x64Multiply(m, n) {
+		//
+		// Given two 64bit ints (as an array of two 32bit ints) returns the two
+		// multiplied together as a 64bit int (as an array of two 32bit ints).
+		//
+		
+		m = [m[0] >>> 16, m[0] & 0xffff, m[1] >>> 16, m[1] & 0xffff];
+		n = [n[0] >>> 16, n[0] & 0xffff, n[1] >>> 16, n[1] & 0xffff];
+		var o = [0, 0, 0, 0];
+		
+		o[3] += m[3] * n[3];
+		o[2] += o[3] >>> 16;
+		o[3] &= 0xffff;
+		
+		o[2] += m[2] * n[3];
+		o[1] += o[2] >>> 16;
+		o[2] &= 0xffff;
+		
+		o[2] += m[3] * n[2];
+		o[1] += o[2] >>> 16;
+		o[2] &= 0xffff;
+		
+		o[1] += m[1] * n[3];
+		o[0] += o[1] >>> 16;
+		o[1] &= 0xffff;
+		
+		o[1] += m[2] * n[2];
+		o[0] += o[1] >>> 16;
+		o[1] &= 0xffff;
+		
+		o[1] += m[3] * n[1];
+		o[0] += o[1] >>> 16;
+		o[1] &= 0xffff;
+		
+		o[0] += (m[0] * n[3]) + (m[1] * n[2]) + (m[2] * n[1]) + (m[3] * n[0]);
+		o[0] &= 0xffff;
+		
+		return [(o[0] << 16) | o[1], (o[2] << 16) | o[3]];
+	}
+	
+	
+	function _x64Rotl(m, n) {
+		//
+		// Given a 64bit int (as an array of two 32bit ints) and an int
+		// representing a number of bit positions, returns the 64bit int (as an
+		// array of two 32bit ints) rotated left by that number of positions.
+		//
+		
+		n %= 64;
+		
+		if (n === 32) {
+			return [m[1], m[0]];
+		}
+		
+		else if (n < 32) {
+			return [(m[0] << n) | (m[1] >>> (32 - n)), (m[1] << n) | (m[0] >>> (32 - n))];
+		}
+		
+		else {
+			n -= 32;
+			return [(m[1] << n) | (m[0] >>> (32 - n)), (m[0] << n) | (m[1] >>> (32 - n))];
+		}
+	}
+	
+	
+	function _x64LeftShift(m, n) {
+		//
+		// Given a 64bit int (as an array of two 32bit ints) and an int
+		// representing a number of bit positions, returns the 64bit int (as an
+		// array of two 32bit ints) shifted left by that number of positions.
+		//
+		
+		n %= 64;
+		
+		if (n === 0) {
+			return m;
+		}
+		
+		else if (n < 32) {
+			return [(m[0] << n) | (m[1] >>> (32 - n)), m[1] << n];
+		}
+		
+		else {
+			return [m[1] << (n - 32), 0];
+		}
+	}
+	
+	
+	function _x64Xor(m, n) {
+		//
+		// Given two 64bit ints (as an array of two 32bit ints) returns the two
+		// xored together as a 64bit int (as an array of two 32bit ints).
+		//
+		
+		return [m[0] ^ n[0], m[1] ^ n[1]];
+	}
+	
+	
+	function _x64Fmix(h) {
+		//
+		// Given a block, returns murmurHash3's final x64 mix of that block.
+		// (`[0, h[0] >>> 1]` is a 33 bit unsigned right shift. This is the
+		// only place where we need to right shift 64bit ints.)
+		//
+		
+		h = _x64Xor(h, [0, h[0] >>> 1]);
+		h = _x64Multiply(h, [0xff51afd7, 0xed558ccd]);
+		h = _x64Xor(h, [0, h[0] >>> 1]);
+		h = _x64Multiply(h, [0xc4ceb9fe, 0x1a85ec53]);
+		h = _x64Xor(h, [0, h[0] >>> 1]);
+		
+		return h;
+	}
+	
+	
+	
+	
+	// PUBLIC FUNCTIONS
+	// ----------------
+	
+	library.x86.hash32 = function (key, seed) {
+		//
+		// Given a string and an optional seed as an int, returns a 32 bit hash
+		// using the x86 flavor of MurmurHash3, as an unsigned int.
+		//
+		
+		key = key || '';
+		seed = seed || 0;
+		
+		var remainder = key.length % 4;
+		var bytes = key.length - remainder;
+		
+		var h1 = seed;
+		
+		var k1 = 0;
+		
+		var c1 = 0xcc9e2d51;
+		var c2 = 0x1b873593;
+		
+		for (var i = 0; i < bytes; i = i + 4) {
+			k1 = ((key.charCodeAt(i) & 0xff)) | ((key.charCodeAt(i + 1) & 0xff) << 8) | ((key.charCodeAt(i + 2) & 0xff) << 16) | ((key.charCodeAt(i + 3) & 0xff) << 24);
+			
+			k1 = _x86Multiply(k1, c1);
+			k1 = _x86Rotl(k1, 15);
+			k1 = _x86Multiply(k1, c2);
+			
+			h1 ^= k1;
+			h1 = _x86Rotl(h1, 13);
+			h1 = _x86Multiply(h1, 5) + 0xe6546b64;
+		}
+		
+		k1 = 0;
+		
+		switch (remainder) {
+			case 3:
+				k1 ^= (key.charCodeAt(i + 2) & 0xff) << 16;
+			
+			case 2:
+				k1 ^= (key.charCodeAt(i + 1) & 0xff) << 8;
+			
+			case 1:
+				k1 ^= (key.charCodeAt(i) & 0xff);
+				k1 = _x86Multiply(k1, c1);
+				k1 = _x86Rotl(k1, 15);
+				k1 = _x86Multiply(k1, c2);
+				h1 ^= k1;
+		}
+		
+		h1 ^= key.length;
+		h1 = _x86Fmix(h1);
+		
+		return h1 >>> 0;
+	};
+	
+	
+	library.x86.hash128 = function (key, seed) {
+		//
+		// Given a string and an optional seed as an int, returns a 128 bit
+		// hash using the x86 flavor of MurmurHash3, as an unsigned hex.
+		//
+		
+		key = key || '';
+		seed = seed || 0;
+		
+		var remainder = key.length % 16;
+		var bytes = key.length - remainder;
+		
+		var h1 = seed;
+		var h2 = seed;
+		var h3 = seed;
+		var h4 = seed;
+		
+		var k1 = 0;
+		var k2 = 0;
+		var k3 = 0;
+		var k4 = 0;
+		
+		var c1 = 0x239b961b;
+		var c2 = 0xab0e9789;
+		var c3 = 0x38b34ae5;
+		var c4 = 0xa1e38b93;
+		
+		for (var i = 0; i < bytes; i = i + 16) {
+			k1 = ((key.charCodeAt(i) & 0xff)) | ((key.charCodeAt(i + 1) & 0xff) << 8) | ((key.charCodeAt(i + 2) & 0xff) << 16) | ((key.charCodeAt(i + 3) & 0xff) << 24);
+			k2 = ((key.charCodeAt(i + 4) & 0xff)) | ((key.charCodeAt(i + 5) & 0xff) << 8) | ((key.charCodeAt(i + 6) & 0xff) << 16) | ((key.charCodeAt(i + 7) & 0xff) << 24);
+			k3 = ((key.charCodeAt(i + 8) & 0xff)) | ((key.charCodeAt(i + 9) & 0xff) << 8) | ((key.charCodeAt(i + 10) & 0xff) << 16) | ((key.charCodeAt(i + 11) & 0xff) << 24);
+			k4 = ((key.charCodeAt(i + 12) & 0xff)) | ((key.charCodeAt(i + 13) & 0xff) << 8) | ((key.charCodeAt(i + 14) & 0xff) << 16) | ((key.charCodeAt(i + 15) & 0xff) << 24);
+			
+			k1 = _x86Multiply(k1, c1);
+			k1 = _x86Rotl(k1, 15);
+			k1 = _x86Multiply(k1, c2);
+			h1 ^= k1;
+			
+			h1 = _x86Rotl(h1, 19);
+			h1 += h2;
+			h1 = _x86Multiply(h1, 5) + 0x561ccd1b;
+			
+			k2 = _x86Multiply(k2, c2);
+			k2 = _x86Rotl(k2, 16);
+			k2 = _x86Multiply(k2, c3);
+			h2 ^= k2;
+			
+			h2 = _x86Rotl(h2, 17);
+			h2 += h3;
+			h2 = _x86Multiply(h2, 5) + 0x0bcaa747;
+			
+			k3 = _x86Multiply(k3, c3);
+			k3 = _x86Rotl(k3, 17);
+			k3 = _x86Multiply(k3, c4);
+			h3 ^= k3;
+			
+			h3 = _x86Rotl(h3, 15);
+			h3 += h4;
+			h3 = _x86Multiply(h3, 5) + 0x96cd1c35;
+			
+			k4 = _x86Multiply(k4, c4);
+			k4 = _x86Rotl(k4, 18);
+			k4 = _x86Multiply(k4, c1);
+			h4 ^= k4;
+			
+			h4 = _x86Rotl(h4, 13);
+			h4 += h1;
+			h4 = _x86Multiply(h4, 5) + 0x32ac3b17;
+		}
+		
+		k1 = 0;
+		k2 = 0;
+		k3 = 0;
+		k4 = 0;
+		
+		switch (remainder) {
+			case 15:
+				k4 ^= key.charCodeAt(i + 14) << 16;
+			
+			case 14:
+				k4 ^= key.charCodeAt(i + 13) << 8;
+			
+			case 13:
+				k4 ^= key.charCodeAt(i + 12);
+				k4 = _x86Multiply(k4, c4);
+				k4 = _x86Rotl(k4, 18);
+				k4 = _x86Multiply(k4, c1);
+				h4 ^= k4;
+			
+			case 12:
+				k3 ^= key.charCodeAt(i + 11) << 24;
+			
+			case 11:
+				k3 ^= key.charCodeAt(i + 10) << 16;
+			
+			case 10:
+				k3 ^= key.charCodeAt(i + 9) << 8;
+			
+			case 9:
+				k3 ^= key.charCodeAt(i + 8);
+				k3 = _x86Multiply(k3, c3);
+				k3 = _x86Rotl(k3, 17);
+				k3 = _x86Multiply(k3, c4);
+				h3 ^= k3;
+			
+			case 8:
+				k2 ^= key.charCodeAt(i + 7) << 24;
+			
+			case 7:
+				k2 ^= key.charCodeAt(i + 6) << 16;
+			
+			case 6:
+				k2 ^= key.charCodeAt(i + 5) << 8;
+			
+			case 5:
+				k2 ^= key.charCodeAt(i + 4);
+				k2 = _x86Multiply(k2, c2);
+				k2 = _x86Rotl(k2, 16);
+				k2 = _x86Multiply(k2, c3);
+				h2 ^= k2;
+			
+			case 4:
+				k1 ^= key.charCodeAt(i + 3) << 24;
+			
+			case 3:
+				k1 ^= key.charCodeAt(i + 2) << 16;
+			
+			case 2:
+				k1 ^= key.charCodeAt(i + 1) << 8;
+			
+			case 1:
+				k1 ^= key.charCodeAt(i);
+				k1 = _x86Multiply(k1, c1);
+				k1 = _x86Rotl(k1, 15);
+				k1 = _x86Multiply(k1, c2);
+				h1 ^= k1;
+		}
+		
+		h1 ^= key.length;
+		h2 ^= key.length;
+		h3 ^= key.length;
+		h4 ^= key.length;
+		
+		h1 += h2;
+		h1 += h3;
+		h1 += h4;
+		h2 += h1;
+		h3 += h1;
+		h4 += h1;
+		
+		h1 = _x86Fmix(h1);
+		h2 = _x86Fmix(h2);
+		h3 = _x86Fmix(h3);
+		h4 = _x86Fmix(h4);
+		
+		h1 += h2;
+		h1 += h3;
+		h1 += h4;
+		h2 += h1;
+		h3 += h1;
+		h4 += h1;
+		
+		return ("00000000" + (h1 >>> 0).toString(16)).slice(-8) + ("00000000" + (h2 >>> 0).toString(16)).slice(-8) + ("00000000" + (h3 >>> 0).toString(16)).slice(-8) + ("00000000" + (h4 >>> 0).toString(16)).slice(-8);
+	};
+	
+	
+	library.x64.hash128 = function (key, seed) {
+		//
+		// Given a string and an optional seed as an int, returns a 128 bit
+		// hash using the x64 flavor of MurmurHash3, as an unsigned hex.
+		//
+		
+		key = key || '';
+		seed = seed || 0;
+		
+		var remainder = key.length % 16;
+		var bytes = key.length - remainder;
+		
+		var h1 = [0, seed];
+		var h2 = [0, seed];
+		
+		var k1 = [0, 0];
+		var k2 = [0, 0];
+		
+		var c1 = [0x87c37b91, 0x114253d5];
+		var c2 = [0x4cf5ad43, 0x2745937f];
+		
+		for (var i = 0; i < bytes; i = i + 16) {
+			k1 = [((key.charCodeAt(i + 4) & 0xff)) | ((key.charCodeAt(i + 5) & 0xff) << 8) | ((key.charCodeAt(i + 6) & 0xff) << 16) | ((key.charCodeAt(i + 7) & 0xff) << 24), ((key.charCodeAt(i) & 0xff)) | ((key.charCodeAt(i + 1) & 0xff) << 8) | ((key.charCodeAt(i + 2) & 0xff) << 16) | ((key.charCodeAt(i + 3) & 0xff) << 24)];
+			k2 = [((key.charCodeAt(i + 12) & 0xff)) | ((key.charCodeAt(i + 13) & 0xff) << 8) | ((key.charCodeAt(i + 14) & 0xff) << 16) | ((key.charCodeAt(i + 15) & 0xff) << 24), ((key.charCodeAt(i + 8) & 0xff)) | ((key.charCodeAt(i + 9) & 0xff) << 8) | ((key.charCodeAt(i + 10) & 0xff) << 16) | ((key.charCodeAt(i + 11) & 0xff) << 24)];
+			
+			k1 = _x64Multiply(k1, c1);
+			k1 = _x64Rotl(k1, 31);
+			k1 = _x64Multiply(k1, c2);
+			h1 = _x64Xor(h1, k1);
+			
+			h1 = _x64Rotl(h1, 27);
+			h1 = _x64Add(h1, h2);
+			h1 = _x64Add(_x64Multiply(h1, [0, 5]), [0, 0x52dce729]);
+			
+			k2 = _x64Multiply(k2, c2);
+			k2 = _x64Rotl(k2, 33);
+			k2 = _x64Multiply(k2, c1);
+			h2 = _x64Xor(h2, k2);
+			
+			h2 = _x64Rotl(h2, 31);
+			h2 = _x64Add(h2, h1);
+			h2 = _x64Add(_x64Multiply(h2, [0, 5]), [0, 0x38495ab5]);
+		}
+		
+		k1 = [0, 0];
+		k2 = [0, 0];
+		
+		switch(remainder) {
+			case 15:
+				k2 = _x64Xor(k2, _x64LeftShift([0, key.charCodeAt(i + 14)], 48));
+			
+			case 14:
+				k2 = _x64Xor(k2, _x64LeftShift([0, key.charCodeAt(i + 13)], 40));
+			
+			case 13:
+				k2 = _x64Xor(k2, _x64LeftShift([0, key.charCodeAt(i + 12)], 32));
+			
+			case 12:
+				k2 = _x64Xor(k2, _x64LeftShift([0, key.charCodeAt(i + 11)], 24));
+			
+			case 11:
+				k2 = _x64Xor(k2, _x64LeftShift([0, key.charCodeAt(i + 10)], 16));
+			
+			case 10:
+				k2 = _x64Xor(k2, _x64LeftShift([0, key.charCodeAt(i + 9)], 8));
+			
+			case 9:
+				k2 = _x64Xor(k2, [0, key.charCodeAt(i + 8)]);
+				k2 = _x64Multiply(k2, c2);
+				k2 = _x64Rotl(k2, 33);
+				k2 = _x64Multiply(k2, c1);
+				h2 = _x64Xor(h2, k2);
+			
+			case 8:
+				k1 = _x64Xor(k1, _x64LeftShift([0, key.charCodeAt(i + 7)], 56));
+			
+			case 7:
+				k1 = _x64Xor(k1, _x64LeftShift([0, key.charCodeAt(i + 6)], 48));
+			
+			case 6:
+				k1 = _x64Xor(k1, _x64LeftShift([0, key.charCodeAt(i + 5)], 40));
+			
+			case 5:
+				k1 = _x64Xor(k1, _x64LeftShift([0, key.charCodeAt(i + 4)], 32));
+			
+			case 4:
+				k1 = _x64Xor(k1, _x64LeftShift([0, key.charCodeAt(i + 3)], 24));
+			
+			case 3:
+				k1 = _x64Xor(k1, _x64LeftShift([0, key.charCodeAt(i + 2)], 16));
+			
+			case 2:
+				k1 = _x64Xor(k1, _x64LeftShift([0, key.charCodeAt(i + 1)], 8));
+			
+			case 1:
+				k1 = _x64Xor(k1, [0, key.charCodeAt(i)]);
+				k1 = _x64Multiply(k1, c1);
+				k1 = _x64Rotl(k1, 31);
+				k1 = _x64Multiply(k1, c2);
+				h1 = _x64Xor(h1, k1);
+		}
+		
+		h1 = _x64Xor(h1, [0, key.length]);
+		h2 = _x64Xor(h2, [0, key.length]);
+		
+		h1 = _x64Add(h1, h2);
+		h2 = _x64Add(h2, h1);
+		
+		h1 = _x64Fmix(h1);
+		h2 = _x64Fmix(h2);
+		
+		h1 = _x64Add(h1, h2);
+		h2 = _x64Add(h2, h1);
+		
+		return ("00000000" + (h1[0] >>> 0).toString(16)).slice(-8) + ("00000000" + (h1[1] >>> 0).toString(16)).slice(-8) + ("00000000" + (h2[0] >>> 0).toString(16)).slice(-8) + ("00000000" + (h2[1] >>> 0).toString(16)).slice(-8);
+	};
+	
+	
+	
+	
+	// INITIALIZATION
+	// --------------
+	
+	// Export murmurHash3 for CommonJS, either as an AMD module or just as part
+	// of the global object.
+	if (typeof exports !== 'undefined') {
+		if (typeof module !== 'undefined' && module.exports) {
+			exports = module.exports = library;
+		}
+		
+		exports.murmurHash3 = library;
+	}
+	
+	else if (typeof define === 'function' && define.amd) {
+		define([], function() {
+			return library;
+		});
+	}
+	
+	else {
+		// Use murmurHash3.noConflict to restore `murmurHash3` back to its
+		// original value. Returns a reference to the library object, to allow
+		// it to be used under a different name.
+		library._murmurHash3 = root.murmurHash3
+		
+		library.noConflict = function () {
+			root.murmurHash3 = library._murmurHash3;
+			library._murmurHash3 = undefined;
+			library.noConflict = undefined;
+			
+			return library;
+		};
+		
+		root.murmurHash3 = library;
+	}
+})(this);

--- a/src/server/engine/mod.rs
+++ b/src/server/engine/mod.rs
@@ -335,8 +335,14 @@ impl<'d> Engine<'d> {
             Ok(false) => {
                 match self.auth.login(&*name, &secret) {
                     Ok(true) => {
-                        //warn_on_err!(logic::client::login(self.as_ref(), wire_id, &*name));
-                        (0, String::new())
+                        match logic::client::update_look(self.as_ref(), &*name, appearance) {
+                            Ok(()) => (0, String::new()),
+                            Err(e) => {
+                                warn!("{:?}: error updating appearance as {}: {}",
+                                      wire_id, name, e.description());
+                                (2, String::from("An internal error occurred."))
+                            }
+                        }
                     },
                     Ok(false) => {
                         info!("{:?}: registration as {} failed: name is in use",

--- a/src/server/engine/mod.rs
+++ b/src/server/engine/mod.rs
@@ -333,9 +333,22 @@ impl<'d> Engine<'d> {
                 }
             },
             Ok(false) => {
-                info!("{:?}: registration as {} failed: name is in use",
-                      wire_id, name);
-                (1, String::from("That name is already in use."))
+                match self.auth.login(&*name, &secret) {
+                    Ok(true) => {
+                        //warn_on_err!(logic::client::login(self.as_ref(), wire_id, &*name));
+                        (0, String::new())
+                    },
+                    Ok(false) => {
+                        info!("{:?}: registration as {} failed: name is in use",
+                              wire_id, name);
+                        (1, String::from("That name is already in use."))
+                    },
+                    Err(e) => {
+                        info!("{:?}: registration/login as {} failed: auth error: {}",
+                              wire_id, name, e.description());
+                        (2, String::from("An internal error occurred."))
+                    },
+                }
             },
             Err(e) => {
                 info!("{:?}: registration as {} failed: database error: {}",


### PR DESCRIPTION
I added the ability to login as your earlier name if you had set and remember your password, and to also change the look of your character if you wanted to. I've never done Rust (or even worked on a multiplayer game) before, so let me know if anything seems blatantly wrong.

Highlights:
- The new password is hashed, and so the secret is still used and most of the flow is preserved (the hash is secure enough that access to it won't reveal the user's password without significant effort)
- The hashing mechanism uses an external library that I added (murmurHash3) -I did it since if a user doesn't have crypto in the browser, a hand-rolled hash function would've been used anyways
- Registration now checks if the secret you submitted corresponds exactly to an earlier one, and logs you in if it does (but only if the name matches)
- You can change appearance (only color, mane/tail/eye styles) on each login, since I figured it is just cosmetic and you might want to keep the same name. You can't change tribes, in case gameplay elements use them in the future.
- I shoved the updating look function inside /src/server/logic/client.rs since that was where all the other saving functions are

Alternatively, I could add an appearance argument to login, if this flow doesn't make as much sense. Or an in-game chat command.

The system is also kinda hacky, but a better system for passwords and sessions would take more time - it works for now.