### PR TITLE
Stop users creating a bunch of indistinguishable dupe accounts

### DIFF
--- a/src/server/engine/mod.rs
+++ b/src/server/engine/mod.rs
@@ -387,6 +387,12 @@ fn name_valid(name: &str) -> Result<(), &'static str> {
     if !has_alnum {
         return Err("Names must contain at least one letter or digit.");
     }
+    if name.contains("  ") {
+        return Err("Names must not have more than one space in a row.");
+    }
+    if name.starts_with(" ") || name.ends_with(" ") {
+        return Err("Names must not start or end with a space.");
+    }
 
     Ok(())
 }


### PR DESCRIPTION
Spaces can be and have been abused in usernames to imitate others, spam and generally cause trouble. They are difficult to see in the chat box (and impossible to see if they occur in the middle of a word!)

Some use this fact legitimately if they lose their cookies/secret, so disabling it will have a downside. However, I believe this prevention is better than cure and should be dealt with by informing users of how to back up secrets. If this is no longer an option, a slightly different username or moderator intervention is still preferable to exploiting this quirk which makes `/permit` confusing.