### PR TITLE
fix import to stop malformed packets bringing down the whole server

### DIFF
--- a/src/auth/verifier/verifier.py
+++ b/src/auth/verifier/verifier.py
@@ -2,6 +2,7 @@ import configparser
 import os
 import struct
 import sys
+import traceback
 
 import nacl.bindings
 import nacl.signing


### PR DESCRIPTION
Errors in the verifier are caught and a stack trace is printed with `traceback`, but the missing import means this causes another error, which bubbles up and brings down the whole server.